### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,14 @@ For clients with straightforward needs one high level API client is provided in 
 
 ### Requirements
 
-- .NET Standard 2.0 or later
+- [.NET Standard 2.0](https://github.com/dotnet/standard/blob/master/docs/versions.md) or later
 - A registered app on the [Forge Developer Portal](http://forge.autodesk.com). 
 
 ### Dependencies
 
-- [Newtonsoft.Json](https://github.com/JamesNK/Newtonsoft.Json) 12.0.1 or later
-- [Autodesk.Forge.Core](https://github.com/autodesk-forge/forge-api-dotnet-shared) assembly which provides services such as: 1. Acquisition of [2 legged oauth token](https://forge.autodesk.com/en/docs/oauth/v2/tutorials/get-2-legged-token/) (and refreshing it when it expires) 2. Preconfigurated resiliency patterns (e.g. retry) using [Polly](https://github.com/App-vNext/Polly)
+- [Autodesk.Forge.Core](https://github.com/autodesk-forge/forge-api-dotnet-shared) assembly which provides services such as: 
+    - Acquisition of [2 legged oauth token](https://forge.autodesk.com/en/docs/oauth/v2/tutorials/get-2-legged-token/) (and refreshing it when it expires) 
+    - Preconfigurated resiliency patterns (e.g. retry) using [Polly](https://github.com/App-vNext/Polly)
 
 ### Changelog
 


### PR DESCRIPTION
1. Add link to .NET Standard
2. Remove Newtonsoft.Json as a dependency since this comes from Autodesk.Forge.Core anyway.
3. Some minor formatting change