### PR TITLE
support another way to define stringArgument

### DIFF
--- a/src/Autodesk.Forge.DesignAutomation/Model/ArgumentConverter.cs
+++ b/src/Autodesk.Forge.DesignAutomation/Model/ArgumentConverter.cs
@@ -48,7 +48,7 @@ namespace Autodesk.Forge.DesignAutomation.Model
                 }
                 else
                 {
-                    throw new JsonSerializationException($"Expected XrefTreeArgument or StringArgument.");
+                    throw new JsonSerializationException("Expected XrefTreeArgument or StringArgument.");
                 }
             }
             else if (reader.TokenType == JsonToken.String)
@@ -57,7 +57,7 @@ namespace Autodesk.Forge.DesignAutomation.Model
             }
             else
             {
-                throw new JsonSerializationException($"Expected object or string but got {reader.TokenType}.");
+                throw new JsonReaderException($"Expected object or string but got {reader.TokenType}.");
             }
 
             return target;

--- a/src/Autodesk.Forge.DesignAutomation/Model/ArgumentConverter.cs
+++ b/src/Autodesk.Forge.DesignAutomation/Model/ArgumentConverter.cs
@@ -33,25 +33,34 @@ namespace Autodesk.Forge.DesignAutomation.Model
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
+            IArgument target;
             if (reader.TokenType == JsonToken.StartObject)
             {
-                IArgument target;
-                var jObject = JObject.Load(reader);
-                if (jObject.Property("url") != null)
+                JObject jObject = JObject.Load(reader);
+                if (jObject["url"] != null)
                 {
                     target = new XrefTreeArgument();
+                    serializer.Populate(jObject.CreateReader(), target);
+                }
+                else if (jObject["value"] != null)
+                {
+                    target = new StringArgument(jObject["value"].Value<string>());
                 }
                 else
                 {
-                    target = new StringArgument();
+                    throw new JsonSerializationException($"Expected XrefTreeArgument or StringArgument.");
                 }
-                serializer.Populate(jObject.CreateReader(), target);
-                return target;
+            }
+            else if (reader.TokenType == JsonToken.String)
+            {
+                target = new StringArgument(reader.Value.ToString());
             }
             else
             {
-                throw new JsonReaderException("Expected start of object.");
+                throw new JsonSerializationException($"Expected object or string but got {reader.TokenType}.");
             }
+
+            return target;
         }
     }
 }

--- a/src/Autodesk.Forge.DesignAutomation/Model/StringArgument.gen.cs
+++ b/src/Autodesk.Forge.DesignAutomation/Model/StringArgument.gen.cs
@@ -41,10 +41,15 @@ namespace Autodesk.Forge.DesignAutomation.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="StringArgument" /> class.
         /// </summary>
+        public StringArgument(string v) : base()
+        {
+            this.Value = v;
+        }
+
         public StringArgument() : base()
         {
         }
-        
+
         /// <summary>
         /// Gets or Sets Value
         /// </summary>

--- a/tests/e2e/TestActivities.cs
+++ b/tests/e2e/TestActivities.cs
@@ -43,6 +43,7 @@ namespace E2eTests
             {
                 { "dwg", new Parameter() { Verb = Verb.Get } },
                 { "params", new Parameter() { Verb = Verb.Read, LocalName = "params.json"} },
+                { "token", new Parameter() { Verb = Verb.Read } },
                 { "results", new Parameter() {Verb = Verb.Post, LocalName = "outputs", Zip = true } }
             },
             Id = "MyAct",

--- a/tests/e2e/TestWorkitems.cs
+++ b/tests/e2e/TestWorkitems.cs
@@ -103,5 +103,63 @@ namespace E2eTests
                 Assert.Equal(Status.Success, resp.Status);
             }
         }
+
+        [Theory]
+        [InlineData(@"
+                {
+                    'activityId' : 'SdkTester.MyAct+latest',
+                    'arguments' : {
+                        'bad' : { 'bla' : 'http://example.com/test.dwg'},
+                    }
+                }")]
+        [InlineData(@"
+                {
+                    'activityId' : 'SdkTester.MyAct+latest',
+                    'arguments' : {
+                        'bad' : {},
+                    }
+                }")]
+        [InlineData(@"
+                {
+                    'activityId' : 'SdkTester.MyAct+latest',
+                    'arguments' : {
+                        'bad' : { 'requestConent': 'request body', 'verb' : 'get'},
+                    }
+                }")]
+        [Order(Weight = 3.0)]
+        public void DeserializeWorkItem_SerializationException(string json)
+        {
+            var ex = Assert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<WorkItem>(json));
+            Assert.Equal("Expected XrefTreeArgument or StringArgument.", ex.Message);
+        }
+
+        [Theory]
+        [InlineData(@"
+                {
+                    'activityId' : 'SdkTester.MyAct+latest',
+                    'arguments' : {
+                        'bad' : [ 'bla' ]
+                    }
+                }", "StartArray")]
+        [InlineData(@"
+                {
+                    'activityId' : 'SdkTester.MyAct+latest',
+                    'arguments' : {
+                        'bad' : 101
+                    }
+                }", "Integer")]
+        [InlineData(@"
+                {
+                    'activityId' : 'SdkTester.MyAct+latest',
+                    'arguments' : {
+                        'bad' : false
+                    }
+                }", "Boolean")]
+        [Order(Weight = 3.0)]
+        public void DeserializeWorkItem_ReaderException(string json, string errorType)
+        {
+            var ex = Assert.Throws<JsonReaderException>(() => JsonConvert.DeserializeObject<WorkItem>(json));
+            Assert.Contains(errorType, ex.Message);
+        }
     }
 }

--- a/tests/e2e/TestWorkitems.cs
+++ b/tests/e2e/TestWorkitems.cs
@@ -42,7 +42,7 @@ namespace E2eTests
                     Arguments = new Dictionary<string, IArgument>
                     {
                         { "dwg",  new XrefTreeArgument() { Url = "http://download.autodesk.com/us/samplefiles/acad/blocks_and_tables_-_imperial.dwg" } },
-                        { "params", new StringArgument() {Value = "{ 'ExtractBlockNames': true, 'ExtractLayerNames' : true }" }},
+                        { "params", new StringArgument() { Value = "{ 'ExtractBlockNames': true, 'ExtractLayerNames' : true }" }},
                         { "token", new StringArgument("IamToken!")},
                         { "results", new XrefTreeArgument { Verb=Verb.Put, Headers = new Dictionary<string, string>() { { "Content-Type", "binary/octet-stream" } }, Url = "https://dasdev-testing.s3.us-west-2.amazonaws.com/sdktest?X-Amz-Expires=89925&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIZLLKUTZMHO46VTQ/20190103/us-west-2/s3/aws4_request&X-Amz-Date=20190103T025815Z&X-Amz-SignedHeaders=content-type;host&X-Amz-Signature=4bfe24c8855360be63c9c5915deba8750cf7724a532ebfb4fe996872f57d3541" } }
                     }
@@ -62,5 +62,46 @@ namespace E2eTests
             }
         }
 
+        [Fact]
+        [Order(Weight = 3.0)]
+        public async void WorkItems_CreateWithStringPayload()
+        {
+            using (var testScope = Fixture.StartTestScope())
+            {
+                var activityAlias = $"{this.nickname}.{this.act.Id}+latest";
+                var payloadString = string.Format(@"
+                {{
+                    'activityId' : '{0}',
+                    'arguments' : {{
+                        'dwg' : {{ 'url' : 'http://download.autodesk.com/us/samplefiles/acad/blocks_and_tables_-_imperial.dwg' }},
+                        'params' : {{ 'value' : '{{ \'ExtractBlockNames\': true, \'ExtractLayerNames\' : true }}' }},
+                        'token' : 'IamToken!',
+                        'results' : 
+                        {{ 
+                            'url' : 'https://dasdev-testing.s3.us-west-2.amazonaws.com/sdktest?X-Amz-Expires=89925&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIZLLKUTZMHO46VTQ/20190103/us-west-2/s3/aws4_request&X-Amz-Date=20190103T025815Z&X-Amz-SignedHeaders=content-type;host&X-Amz-Signature=4bfe24c8855360be63c9c5915deba8750cf7724a532ebfb4fe996872f57d3541',
+                            'verb': 'put',
+                            'headers': 
+                            {{
+                              'Content-Type': 'binary/octet-stream'
+                            }}
+                        }}
+                    }}
+                }}", activityAlias);
+
+                var wi = JsonConvert.DeserializeObject<WorkItem>(payloadString);
+
+                var resp = await Fixture.DesignAutomationClient.CreateWorkItemAsync(wi);
+                Assert.Equal(Status.Pending, resp.Status);
+                while (!resp.Status.IsDone())
+                {
+                    if (testScope.IsRecording)
+                    {
+                        await Task.Delay(TimeSpan.FromSeconds(5));
+                    }
+                    resp = await Fixture.DesignAutomationClient.GetWorkitemStatusAsync(resp.Id);
+                }
+                Assert.Equal(Status.Success, resp.Status);
+            }
+        }
     }
 }

--- a/tests/e2e/TestWorkitems.cs
+++ b/tests/e2e/TestWorkitems.cs
@@ -43,6 +43,7 @@ namespace E2eTests
                     {
                         { "dwg",  new XrefTreeArgument() { Url = "http://download.autodesk.com/us/samplefiles/acad/blocks_and_tables_-_imperial.dwg" } },
                         { "params", new StringArgument() {Value = "{ 'ExtractBlockNames': true, 'ExtractLayerNames' : true }" }},
+                        { "token", new StringArgument("IamToken!")},
                         { "results", new XrefTreeArgument { Verb=Verb.Put, Headers = new Dictionary<string, string>() { { "Content-Type", "binary/octet-stream" } }, Url = "https://dasdev-testing.s3.us-west-2.amazonaws.com/sdktest?X-Amz-Expires=89925&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIZLLKUTZMHO46VTQ/20190103/us-west-2/s3/aws4_request&X-Amz-Date=20190103T025815Z&X-Amz-SignedHeaders=content-type;host&X-Amz-Signature=4bfe24c8855360be63c9c5915deba8750cf7724a532ebfb4fe996872f57d3541" } }
                     }
                 };

--- a/tests/e2e/recordings/Activities_Create.json
+++ b/tests/e2e/recordings/Activities_Create.json
@@ -14,6 +14,9 @@
             "verb": "read",
             "localName": "params.json"
           },
+          "token": {
+            "verb": "read"
+          },
           "results": {
             "zip": true,
             "verb": "post",
@@ -55,6 +58,9 @@
             "params": {
               "verb": "read",
               "localName": "params.json"
+            },
+            "token": {
+              "verb": "read"
             },
             "results": {
               "zip": true,

--- a/tests/e2e/recordings/WorkItems_Create.json
+++ b/tests/e2e/recordings/WorkItems_Create.json
@@ -30,6 +30,9 @@
             "params": {
               "value": "{ 'ExtractBlockNames': true, 'ExtractLayerNames' : true }"
             },
+            "token": {
+              "value": "IamToken!"
+            },
             "results": {
               "url": "https://dasdev-testing.s3.us-west-2.amazonaws.com/sdktest?X-Amz-Expires=89925&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIZLLKUTZMHO46VTQ/20190103/us-west-2/s3/aws4_request&X-Amz-Date=20190103T025815Z&X-Amz-SignedHeaders=content-type;host&X-Amz-Signature=4bfe24c8855360be63c9c5915deba8750cf7724a532ebfb4fe996872f57d3541",
               "headers": {

--- a/tests/e2e/recordings/WorkItems_CreateWithStringPayload.json
+++ b/tests/e2e/recordings/WorkItems_CreateWithStringPayload.json
@@ -5,9 +5,9 @@
       "Body": {
         "status": "pending",
         "stats": {
-          "timeQueued": "2019-01-03T06:02:40.9081695Z"
+          "timeQueued": "2019-08-13T06:02:40.9081695Z"
         },
-        "id": "1737a8ec8c634298a3747d18ba9bf95d"
+        "id": "8970a8ec12345298a3747d18ba9bf95d"
       },
       "Headers": {
         "Content-Type": "application/json"
@@ -53,14 +53,14 @@
     "Content": {
       "Body": {
         "status": "success",
-        "reportUrl": "https://dasprod-store.s3.amazonaws.com/workItem/SdkTester/1737a8ec8c634298a3747d18ba9bf95d/report.txt?AWSAccessKeyId=ASIATGVJZKM3HBAEFTHT&Expires=1546498966&x-amz-security-token=FQoGZXIvYXdzEJ7%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaDEmIckCvKn8%2F87Z0SCL9AYafE8PsudHLPcBjJ48uhdWudR%2BMrM8DH9FO1saphGUvXzrPsiWNaYs5AYCfzMEW7QGjmdqOQmcRAlipNyh0zoiNUFeBkc3LmntyJkIwo7dbyh8aUe2mhLb0b%2FLHe2jfuGtUE%2FGge%2FacqFXzZ57sn4ee9FbypIly2J63gNfKsloFqHSjwufi2pvnB8wUS4lX%2BYdWfJEImJLv3qY%2BCCXzJT9WR8%2B8605h3MQPXG72CIcWAv2A7RCDc8CFt2v5pg%2Bq1UpKdUzOcOrEmGYE6Eoo0RuAmNf%2FV8tKAWX%2BhLCXQ2mR66FULC73LInGIE8dPGmFyayDtFMUanv3gNxPVmEogZu24QU%3D&Signature=gRbfaWvC%2FTSxrOyn%2FGvj5YjBFAw%3D",
+        "reportUrl": "https://dasprod-store.s3.amazonaws.com/workItem/SdkTester/8970a8ec12345298a3747d18ba9bf95d/report.txt?AWSAccessKeyId=ASIATGVJZKM3HBAEFTHT&Expires=1546498966&x-amz-security-token=FQoGZXIvYXdzEJ7%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaDEmIckCvKn8%2F87Z0SCL9AYafE8PsudHLPcBjJ48uhdWudR%2BMrM8DH9FO1saphGUvXzrPsiWNaYs5AYCfzMEW7QGjmdqOQmcRAlipNyh0zoiNUFeBkc3LmntyJkIwo7dbyh8aUe2mhLb0b%2FLHe2jfuGtUE%2FGge%2FacqFXzZ57sn4ee9FbypIly2J63gNfKsloFqHSjwufi2pvnB8wUS4lX%2BYdWfJEImJLv3qY%2BCCXzJT9WR8%2B8605h3MQPXG72CIcWAv2A7RCDc8CFt2v5pg%2Bq1UpKdUzOcOrEmGYE6Eoo0RuAmNf%2FV8tKAWX%2BhLCXQ2mR66FULC73LInGIE8dPGmFyayDtFMUanv3gNxPVmEogZu24QU%3D&Signature=gRbfaWvC%2FTSxrOyn%2FGvj5YjBFAw%3D",
         "stats": {
-          "timeQueued": "2019-01-03T06:02:40.9081695Z",
-          "timeDownloadStarted": "2019-01-03T06:02:41.1777074Z",
-          "timeInstructionsStarted": "2019-01-03T06:02:41.349623Z",
-          "timeInstructionsEnded": "2019-01-03T06:02:42.3496219Z",
-          "timeUploadEnded": "2019-01-03T06:02:42.7089659Z",
-          "timeFinished": "2019-01-03T06:02:42.824428Z"
+          "timeQueued": "2019-08-13T06:02:40.9081695Z",
+          "timeDownloadStarted": "2019-08-13T06:02:41.1777074Z",
+          "timeInstructionsStarted": "2019-08-13T06:02:41.349623Z",
+          "timeInstructionsEnded": "2019-08-13T06:02:42.3496219Z",
+          "timeUploadEnded": "2019-08-13T06:02:42.7089659Z",
+          "timeFinished": "2019-08-13T06:02:42.824428Z"
         },
         "id": "8970a8ec12345298a3747d18ba9bf95d"
       },
@@ -70,7 +70,7 @@
     },
     "Request": {
       "Method": "GET",
-      "RequestUri": "https://developer.api.autodesk.com/da/us-east/v3/workitems/1737a8ec8c634298a3747d18ba9bf95d",
+      "RequestUri": "https://developer.api.autodesk.com/da/us-east/v3/workitems/8970a8ec12345298a3747d18ba9bf95d",
       "Headers": {
         "Accept": "application/json",
         "Authorization": "***"

--- a/tests/e2e/recordings/WorkItems_CreateWithStringPayload.json
+++ b/tests/e2e/recordings/WorkItems_CreateWithStringPayload.json
@@ -1,0 +1,80 @@
+[
+  {
+    "StatusCode": 200,
+    "Content": {
+      "Body": {
+        "status": "pending",
+        "stats": {
+          "timeQueued": "2019-01-03T06:02:40.9081695Z"
+        },
+        "id": "1737a8ec8c634298a3747d18ba9bf95d"
+      },
+      "Headers": {
+        "Content-Type": "application/json"
+      }
+    },
+    "Request": {
+      "Method": "POST",
+      "RequestUri": "https://developer.api.autodesk.com/da/us-east/v3/workitems",
+      "Headers": {
+        "Accept": "application/json",
+        "Authorization": "***"
+      },
+      "Content": {
+        "Body": {
+          "activityId": "SdkTester.MyAct+latest",
+          "arguments": {
+            "dwg": {
+              "url": "http://download.autodesk.com/us/samplefiles/acad/blocks_and_tables_-_imperial.dwg"
+            },
+            "params": {
+              "value": "{ 'ExtractBlockNames': true, 'ExtractLayerNames' : true }"
+            },
+            "token": {
+              "value": "IamToken!"
+            },
+            "results": {
+              "url": "https://dasdev-testing.s3.us-west-2.amazonaws.com/sdktest?X-Amz-Expires=89925&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIZLLKUTZMHO46VTQ/20190103/us-west-2/s3/aws4_request&X-Amz-Date=20190103T025815Z&X-Amz-SignedHeaders=content-type;host&X-Amz-Signature=4bfe24c8855360be63c9c5915deba8750cf7724a532ebfb4fe996872f57d3541",
+              "headers": {
+                "Content-Type": "binary/octet-stream"
+              },
+              "verb": "put"
+            }
+          }
+        },
+        "Headers": {
+          "Content-Type": "application/json"
+        }
+      }
+    }
+  },
+  {
+    "StatusCode": 200,
+    "Content": {
+      "Body": {
+        "status": "success",
+        "reportUrl": "https://dasprod-store.s3.amazonaws.com/workItem/SdkTester/1737a8ec8c634298a3747d18ba9bf95d/report.txt?AWSAccessKeyId=ASIATGVJZKM3HBAEFTHT&Expires=1546498966&x-amz-security-token=FQoGZXIvYXdzEJ7%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaDEmIckCvKn8%2F87Z0SCL9AYafE8PsudHLPcBjJ48uhdWudR%2BMrM8DH9FO1saphGUvXzrPsiWNaYs5AYCfzMEW7QGjmdqOQmcRAlipNyh0zoiNUFeBkc3LmntyJkIwo7dbyh8aUe2mhLb0b%2FLHe2jfuGtUE%2FGge%2FacqFXzZ57sn4ee9FbypIly2J63gNfKsloFqHSjwufi2pvnB8wUS4lX%2BYdWfJEImJLv3qY%2BCCXzJT9WR8%2B8605h3MQPXG72CIcWAv2A7RCDc8CFt2v5pg%2Bq1UpKdUzOcOrEmGYE6Eoo0RuAmNf%2FV8tKAWX%2BhLCXQ2mR66FULC73LInGIE8dPGmFyayDtFMUanv3gNxPVmEogZu24QU%3D&Signature=gRbfaWvC%2FTSxrOyn%2FGvj5YjBFAw%3D",
+        "stats": {
+          "timeQueued": "2019-01-03T06:02:40.9081695Z",
+          "timeDownloadStarted": "2019-01-03T06:02:41.1777074Z",
+          "timeInstructionsStarted": "2019-01-03T06:02:41.349623Z",
+          "timeInstructionsEnded": "2019-01-03T06:02:42.3496219Z",
+          "timeUploadEnded": "2019-01-03T06:02:42.7089659Z",
+          "timeFinished": "2019-01-03T06:02:42.824428Z"
+        },
+        "id": "8970a8ec12345298a3747d18ba9bf95d"
+      },
+      "Headers": {
+        "Content-Type": "application/json"
+      }
+    },
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://developer.api.autodesk.com/da/us-east/v3/workitems/1737a8ec8c634298a3747d18ba9bf95d",
+      "Headers": {
+        "Accept": "application/json",
+        "Authorization": "***"
+      }
+    }
+  }
+]


### PR DESCRIPTION
We support two ways to define  `StringArgument` in the WI payload:
1. `"key": {"value": "IamSomehing"}` 
2. `"key": "IamSomehing"`. 

This PR updates the `ReadJson` to enable to handle the 2nd way and also add test to cover the 2nd way in the WI payload