### PR TITLE
Fix missing enum

### DIFF
--- a/src/Autodesk.Forge.DesignAutomation/Autodesk.Forge.DesignAutomation.csproj
+++ b/src/Autodesk.Forge.DesignAutomation/Autodesk.Forge.DesignAutomation.csproj
@@ -9,7 +9,7 @@
     <Product>Autodesk Forge</Product>
     <Description>Client sdk for Forge DesignAutomation API</Description>
     <Copyright>Autodesk Inc.</Copyright>
-    <Version>4.1.0</Version>
+    <Version>4.2.0</Version>
     <PackageId>Autodesk.Forge.DesignAutomation</PackageId>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/Autodesk-Forge/forge-api-dotnet-design.automation</PackageProjectUrl>

--- a/src/Autodesk.Forge.DesignAutomation/Model/PublicKey.cs
+++ b/src/Autodesk.Forge.DesignAutomation/Model/PublicKey.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 
 namespace Autodesk.Forge.DesignAutomation.Model
 {
@@ -10,6 +11,11 @@ namespace Autodesk.Forge.DesignAutomation.Model
             if (other == null)
                 return false;
             return this.Exponent.SequenceEqual(other.Exponent) && this.Modulus.SequenceEqual(other.Modulus);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Exponent, Modulus);
         }
     }
 }

--- a/src/Autodesk.Forge.DesignAutomation/Model/Status.gen.cs
+++ b/src/Autodesk.Forge.DesignAutomation/Model/Status.gen.cs
@@ -63,6 +63,7 @@ namespace Autodesk.Forge.DesignAutomation.Model
         /// Enum FailedLimitDataSize for value: failedLimitDataSize
         /// </summary>
         [EnumMember(Value = "failedLimitDataSize")]
+        [Obsolete]
         FailedLimitDataSize = 4,
         
         /// <summary>
@@ -88,7 +89,13 @@ namespace Autodesk.Forge.DesignAutomation.Model
         /// </summary>
         [EnumMember(Value = "failedUpload")]
         FailedUpload = 8,
-        
+
+        /// <summary>
+        /// Some optional outputs failed to upload. See report for details.
+        /// </summary>
+        [EnumMember(Value = "failedUploadOptional")]
+        FailedUploadOptional = 10,
+
         /// <summary>
         /// Enum Success for value: success
         /// </summary>


### PR DESCRIPTION
Deprecated enum that the server no longer returns
Add GetHashCode to make the C# compiler happy

Fixes #22.