### PR TITLE
Support multiple agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,14 +82,16 @@ FORGE_CLIENT_SECRET=<your client secret>
  ```
  {
   "Forge": {
+    "ClientId": "<default clientId>"
+    "ClientSecret" : "<default clientSecret>"
     "Agents": {
-      "<agent1>": {
-        "ClientId": "<Some clientId>"
-        "ClientSecret" : "<Some clientSecret>"
+      "agent1": {
+        "ClientId": "<clientId of agent1>"
+        "ClientSecret" : "<clientSecret of agent1>"
       },
-       "<agent2>": {
-        "ClientId": "<Some clientId>"
-        "ClientSecret" : "<Some clientSecret>"
+       "agent2": {
+        "ClientId": "<clientId of agent2>"
+        "ClientSecret" : "<clientSecret of agent2>"
       }
     },
     ...

--- a/README.md
+++ b/README.md
@@ -77,6 +77,26 @@ FORGE_CLIENT_ID=<your client id>
 FORGE_CLIENT_SECRET=<your client secret>
 ```
  
+ Starting with version 4.3 you can also configure multiple ClientId/ClientSecret pairs as follows:
+
+ ```
+ {
+  "Forge": {
+    "Agents": {
+      "<agent1>": {
+        "ClientId": "<Some clientId>"
+        "ClientSecret" : "<Some clientSecret>"
+      },
+       "<agent2>": {
+        "ClientId": "<Some clientId>"
+        "ClientSecret" : "<Some clientSecret>"
+      }
+    },
+    ...
+}
+ ```
+
+ These credentials are used when you create a named `DesignAutomationClient` via [DesignAutomationFactory.CreateClient(string name)](src/Autodesk.Forge.DesignAutomation/ApiClientFactory.cs#L37) where `name` should match the name of the agent in configuration.
 ### Examples
 
 #### Tutorials

--- a/nuget.targets
+++ b/nuget.targets
@@ -4,8 +4,8 @@
   Continue on errors. Publishing can fail if the package version isn't updated and we get conflict.
   -->
   <Target Name="Push" DependsOnTargets="Pack">
-    <Exec Command="dotnet nuget push @(NuGetPackOutput->WithMetadataValue('Extension','.nupkg')) -k=$(NugetApiKey) -s nuget.org"  
-          IgnoreExitCode="true"
-          ContinueOnError="true"/>
+    <Exec Command="dotnet nuget push @(NuGetPackOutput->WithMetadataValue('Extension','.nupkg')) -k=$(NugetApiKey) -s nuget.org --skip-duplicate"
+          IgnoreExitCode="false"
+          ContinueOnError="false"/>
   </Target>
 </Project>

--- a/src/Autodesk.Forge.DesignAutomation/ApiClient.cs
+++ b/src/Autodesk.Forge.DesignAutomation/ApiClient.cs
@@ -151,6 +151,6 @@ namespace Autodesk.Forge.DesignAutomation
             while (paginationToken != null);
             return ret;
         }
-        public string User { get; internal set; }
+        public string Agent { get; internal set; }
     }
 }

--- a/src/Autodesk.Forge.DesignAutomation/ApiClient.cs
+++ b/src/Autodesk.Forge.DesignAutomation/ApiClient.cs
@@ -151,5 +151,6 @@ namespace Autodesk.Forge.DesignAutomation
             while (paginationToken != null);
             return ret;
         }
+        public string User { get; internal set; }
     }
 }

--- a/src/Autodesk.Forge.DesignAutomation/ApiClientFactory.cs
+++ b/src/Autodesk.Forge.DesignAutomation/ApiClientFactory.cs
@@ -34,11 +34,11 @@ namespace Autodesk.Forge.DesignAutomation
         {
             this.services = services;
         }
-        public DesignAutomationClient CreateClient(string user = null)
+        public DesignAutomationClient CreateClient(string agent = null)
         {
             var httpClientFactory = services.GetRequiredService<IHttpClientFactory>();
             var typedClientFactory = services.GetRequiredService<ITypedHttpClientFactory<ForgeService>>();
-            var forgeService = typedClientFactory.CreateClient(httpClientFactory.CreateClient(user));
+            var forgeService = typedClientFactory.CreateClient(httpClientFactory.CreateClient(agent));
             var client = ActivatorUtilities.CreateInstance<DesignAutomationClient>(
                 services, 
                 forgeService,
@@ -50,7 +50,7 @@ namespace Autodesk.Forge.DesignAutomation
                 ActivatorUtilities.CreateInstance<ServiceLimitsApi>(services, forgeService),
                 ActivatorUtilities.CreateInstance<SharesApi>(services, forgeService),
                 ActivatorUtilities.CreateInstance<WorkItemsApi>(services, forgeService)); 
-            client.User = user;
+            client.Agent = agent;
             return client;
         }
     }

--- a/src/Autodesk.Forge.DesignAutomation/ApiClientFactory.cs
+++ b/src/Autodesk.Forge.DesignAutomation/ApiClientFactory.cs
@@ -1,0 +1,57 @@
+﻿/* 
+ * Forge SDK
+ *
+ * The Forge Platform contains an expanding collection of web service components that can be used with Autodesk cloud-based products or your own technologies. Take advantage of Autodesk’s expertise in design and engineering.
+ *
+ * Design Automation
+ *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using Autodesk.Forge.Core;
+using Autodesk.Forge.DesignAutomation.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+
+namespace Autodesk.Forge.DesignAutomation
+{
+    public class DesignAutomationClientFactory
+    {
+        IServiceProvider services;
+        public DesignAutomationClientFactory(IServiceProvider services)
+        {
+            this.services = services;
+        }
+        public DesignAutomationClient CreateClient(string user = null)
+        {
+            var httpClientFactory = services.GetRequiredService<IHttpClientFactory>();
+            var typedClientFactory = services.GetRequiredService<ITypedHttpClientFactory<ForgeService>>();
+            var forgeService = typedClientFactory.CreateClient(httpClientFactory.CreateClient(user));
+            var client = ActivatorUtilities.CreateInstance<DesignAutomationClient>(
+                services, 
+                forgeService,
+                ActivatorUtilities.CreateInstance<ActivitiesApi>(services, forgeService),
+                ActivatorUtilities.CreateInstance<AppBundlesApi>(services, forgeService),
+                ActivatorUtilities.CreateInstance<EnginesApi>(services, forgeService),
+                ActivatorUtilities.CreateInstance<ForgeAppsApi>(services, forgeService),
+                ActivatorUtilities.CreateInstance<HealthApi>(services, forgeService),
+                ActivatorUtilities.CreateInstance<ServiceLimitsApi>(services, forgeService),
+                ActivatorUtilities.CreateInstance<SharesApi>(services, forgeService),
+                ActivatorUtilities.CreateInstance<WorkItemsApi>(services, forgeService)); 
+            client.User = user;
+            return client;
+        }
+    }
+}

--- a/src/Autodesk.Forge.DesignAutomation/Autodesk.Forge.DesignAutomation.csproj
+++ b/src/Autodesk.Forge.DesignAutomation/Autodesk.Forge.DesignAutomation.csproj
@@ -9,7 +9,7 @@
     <Product>Autodesk Forge</Product>
     <Description>Client sdk for Forge DesignAutomation API</Description>
     <Copyright>Autodesk Inc.</Copyright>
-    <Version>4.2.0</Version>
+    <Version>4.3.0</Version>
     <PackageId>Autodesk.Forge.DesignAutomation</PackageId>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/Autodesk-Forge/forge-api-dotnet-design.automation</PackageProjectUrl>
@@ -25,8 +25,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Autodesk.Forge.Core" Version="2.1.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="Autodesk.Forge.Core" Version="2.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
    

--- a/src/Autodesk.Forge.DesignAutomation/ServiceCollectionExtensions.cs
+++ b/src/Autodesk.Forge.DesignAutomation/ServiceCollectionExtensions.cs
@@ -22,7 +22,7 @@
 using Autodesk.Forge.Core;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Autodesk.Forge.DesignAutomation.Http;
+using System;
 
 namespace Autodesk.Forge.DesignAutomation
 {
@@ -34,19 +34,19 @@ namespace Autodesk.Forge.DesignAutomation
         /// <param name="services"></param>
         /// <param name="configuration"></param>
         /// <returns></returns>
-        public static IHttpClientBuilder AddDesignAutomation(this IServiceCollection services, IConfiguration configuration)
+        public static void AddDesignAutomationFactory(this IServiceCollection services, IConfiguration configuration, Action<IHttpClientBuilder> configureBuilder = null)
         {
-            services.Configure<Configuration>(configuration.GetSection("Forge").GetSection("DesignAutomation"));
-            services.AddTransient<IActivitiesApi,ActivitiesApi>();
-            services.AddTransient<IAppBundlesApi,AppBundlesApi>();
-            services.AddTransient<IEnginesApi,EnginesApi>();
-            services.AddTransient<IForgeAppsApi,ForgeAppsApi>();
-            services.AddTransient<IHealthApi,HealthApi>();
-            services.AddTransient<IServiceLimitsApi,ServiceLimitsApi>();
-            services.AddTransient<ISharesApi,SharesApi>();
-            services.AddTransient<IWorkItemsApi,WorkItemsApi>();
-            services.AddTransient<DesignAutomationClient>();
-            return services.AddForgeService(configuration);
+            IHttpClientBuilder builder;
+            foreach (var user in configuration.GetSection("Forge:Agents").GetChildren())
+            {
+                builder = services.AddForgeService(user.Key, configuration);
+                configureBuilder?.Invoke(builder);
+            }
+
+            services.AddSingleton<DesignAutomationClientFactory>();
+            builder = services.AddDesignAutomation(configuration);
+            configureBuilder?.Invoke(builder);
+
         }
     }
 }

--- a/src/Autodesk.Forge.DesignAutomation/ServiceCollectionExtensions.cs
+++ b/src/Autodesk.Forge.DesignAutomation/ServiceCollectionExtensions.cs
@@ -37,9 +37,9 @@ namespace Autodesk.Forge.DesignAutomation
         public static void AddDesignAutomationFactory(this IServiceCollection services, IConfiguration configuration, Action<IHttpClientBuilder> configureBuilder = null)
         {
             IHttpClientBuilder builder;
-            foreach (var user in configuration.GetSection("Forge:Agents").GetChildren())
+            foreach (var agent in configuration.GetSection("Forge:Agents").GetChildren())
             {
-                builder = services.AddForgeService(user.Key, configuration);
+                builder = services.AddForgeService(agent.Key, configuration);
                 configureBuilder?.Invoke(builder);
             }
 


### PR DESCRIPTION
This builds on https://github.com/Autodesk-Forge/forge-api-dotnet-core/pull/84.
Introduce `DesignAutmationClientFactory`. This is similar to `HttpClientFactory`. One can use this to create named clients that use different ClientId/ClientSecret to authenticate. Here's how you can use this:
1. Add multiple "agents" your `appsettings.json` as follows:
```
{
  "Forge": {
    "Agents": {
      "<agent1>": {
        "ClientId": "<Some clientId>"
        "ClientSecret" : "<Some clientSecret>"
      },
       "<agent2>": {
        "ClientId": "<Some clientId>"
        "ClientSecret" : "<Some clientSecret>"
      }
    },
    ...
}
```
2. Register `DesignAutomationClientFactory` in dependency injection container:
```
services.AddDesignAutomationFactory(configuration);
```
3. Use it 
```
SomeObject(DesignAutomationClientFactory factory)
{
   // client will use ClientId/ClientSecret for <agent1> from configuration
   var client = factory.CreateClient("<agent1>");
}
```