### PR TITLE
Fix `GetAllItems` method

### DIFF
--- a/src/Autodesk.Forge.DesignAutomation/ApiClient.cs
+++ b/src/Autodesk.Forge.DesignAutomation/ApiClient.cs
@@ -138,10 +138,7 @@ namespace Autodesk.Forge.DesignAutomation
             {
                 var resp = await pageGetter(paginationToken);
                 paginationToken = resp.PaginationToken;
-                foreach (var d in resp.Data)
-                {
-                    ret.AddRange(resp.Data);
-                }
+                ret.AddRange(resp.Data);
             }
             while (paginationToken != null);
             return ret;


### PR DESCRIPTION
Remove foreach in the `GetAllItems` method, the method was adding multiple data in the result.