### PR TITLE
Github Release == Nuget Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 ![SDK](https://img.shields.io/badge/SDK-5.0.0-lightgree.svg)
 ![.NET](https://img.shields.io/badge/.NET%20-6-blue.svg)
 ![BUILD](https://github.com/Autodesk-Forge/forge-api-dotnet-design.automation/workflows/.NET%20Core/badge.svg?branch=main)
+[![nuget](https://img.shields.io/nuget/v/Autodesk.Forge.DesignAutomation?logo=nuget&color=blue)](https://www.nuget.org/packages/Autodesk.Forge.DesignAutomation)
 
 ## Overview
 


### PR DESCRIPTION
Could someone please create a Release in this repo to match the version in the nuget.

By the way, I add the code below to show the nuget version in the readme. 

[![nuget](https://img.shields.io/nuget/v/Autodesk.Forge.DesignAutomation?logo=nuget&color=blue)](https://www.nuget.org/packages/Autodesk.Forge.DesignAutomation)

```
[![nuget](https://img.shields.io/nuget/v/Autodesk.Forge.DesignAutomation?logo=nuget&color=blue)](https://www.nuget.org/packages/Autodesk.Forge.DesignAutomation)
```

And every time a new version is created in the nuget, should be created in Github as well, this makes it easier to know what changes between the two versions.