### PR TITLE
Update core dependency

### DIFF
--- a/src/Autodesk.Forge.DesignAutomation/Autodesk.Forge.DesignAutomation.csproj
+++ b/src/Autodesk.Forge.DesignAutomation/Autodesk.Forge.DesignAutomation.csproj
@@ -2,11 +2,11 @@
   
   <PropertyGroup>
     <Description>Client sdk for Forge DesignAutomation API</Description>
-    <PackageVersion>6.0.0</PackageVersion>
+    <Version>6.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autodesk.Forge.Core" Version="4.0.0" />
+    <PackageReference Include="Autodesk.Forge.Core" Version="4.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
    

--- a/tests/e2e/E2eTests.csproj
+++ b/tests/e2e/E2eTests.csproj
@@ -18,11 +18,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autodesk.Forge.Core.E2eTestHelpers" Version="4.0.0" />
+    <PackageReference Include="Autodesk.Forge.Core.E2eTestHelpers" Version="4.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Update dependency Forge.Core to 4.0.1 to pick up the latest changes.
Also fixed assembly version which was alway set to 1.0.0. We now use the `<Version>` tag which sets both the assembly and package version.

Fixes issue #90